### PR TITLE
Add "x" permission to cache directory for OS X

### DIFF
--- a/main.go
+++ b/main.go
@@ -236,7 +236,7 @@ func appMain(driver gxui.Driver) {
 	file, config := getConfig()
 	cacheDir := filepath.Join(filepath.Dir(file), "cache")
 	if _, err := os.Stat(cacheDir); err != nil {
-		os.MkdirAll(cacheDir, 0600)
+		os.MkdirAll(cacheDir, 0700)
 	}
 
 	token, authorized, err := getAccessToken(config)


### PR DESCRIPTION
Hi, @mattn 
Thanks for a nice example program "gxuitter"!

I tried to run it on OS X and got following errors.

```
2015/03/20 00:29:08 open /Users/hnakamur/.config/gxuitter/cache/03B5F016B08997F2758C3995EA686671: permission denied
2015/03/20 00:29:08 open /Users/hnakamur/.config/gxuitter/cache/2DFF9702D9601770A62C62F00B87A7DD: permission denied
...(snip)...
```

This pull request fixes these errors.
Could you merge this?
Thanks!
